### PR TITLE
Added "A" and "B" spells, added martial classes, and sorted alphabetically.

### DIFF
--- a/data.json
+++ b/data.json
@@ -405,8 +405,7 @@
           "cost": 1,
           "max-purchases": "-",
           "frequency" : ""
-        }
-      "classes": {
+        },
         "Wizard": {
           "level": 2,
           "cost": 1,

--- a/data.json
+++ b/data.json
@@ -20,7 +20,7 @@
       "type": "Enchantment",
       "school": "Protection",
       "range": "Touch",
-      "materials": "White strip",
+      "materials": "White Strip",
       "classes": {
         "Healer": {
           "level": 2,
@@ -35,7 +35,7 @@
       "type": "Enchantment",
       "school": "Protection",
       "range": "Touch",
-      "materials": "White strip",
+      "materials": "White Strip",
       "classes": {
         "healer": {
           "level": 3,
@@ -109,7 +109,7 @@
       "type": "Enchantment",
       "school": "Protection",
       "range": "Touch",
-      "materials": "White strip",
+      "materials": "White Strip",
       "classes": {
         "healer": {
           "level": 6,
@@ -144,7 +144,7 @@
       "type": "Enchantment",
       "school": "Sorcery",
       "range": "Touch",
-      "materials": "Yellow strip",
+      "materials": "Yellow Strip",
       "classes": {
         "druid": {
           "level": 3,
@@ -182,29 +182,22 @@
       }
     },
     {
-      "name": "Entangle",
-      "type": "Magic Ball",
-      "school": "Subdual",
-      "range": "Ball",
-      "materials": "Brown Magic Ball",
+      "name": "Banish",
+      "type": "Verbal",
+      "school": "Sorcery",
+      "range": "20'",
       "classes": {
-        "druid": {
+        "healer": {
           "level": 1,
           "cost": 1,
-          "max-purchases": 2,
-          "frequency" : "2 Balls/Unlimited"
-        },
-        "healer": {
-          "level": 2,
-          "cost": 1,
-          "max-purchases": 4,
-          "frequency" : "2 Balls/Unlimited"
+          "max-purchases": "-",
+          "frequency" : "1/Life"
         },
         "wizard": {
-          "level": 2,
+          "level": 1,
           "cost": 1,
-          "max-purchases": 3,
-          "frequency" : "2 Balls/Unlimited"
+          "max-purchases": "-",
+          "frequency" : "1/Life"
         }
       }
     },
@@ -219,6 +212,21 @@
           "level": 1,
           "cost": 1,
           "max-purchases": 2,
+          "frequency" : "1/Refresh"
+        }
+      }
+    },
+    {
+      "name": "Bear Strength",
+      "type": "Enchantment",
+      "school": "Sorcery",
+      "range": "Touch",
+      "materials": "Red Strip",
+      "classes": {
+        "druid": {
+          "level": 3,
+          "cost": 1,
+          "max-purchases": "-",
           "frequency" : "1/Refresh"
         }
       }
@@ -265,6 +273,138 @@
         "druid": {
           "level": 1,
           "cost": 1,
+          "max-purchases": 1,
+          "frequency" : "-"
+        }
+      }
+    },
+    {
+      "name": "Dispel Magic",
+      "type": "Verbal",
+      "school": "Sorcery",
+      "range": "20 feet",
+      "classes": {
+        "druid": {
+          "level": 3,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Refresh"
+        },
+        "healer": {
+          "level": 5,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency": "1/Refresh"
+        },
+        "scout": {
+          "level": 3,
+          "cost": 0,
+          "max-purchases": "-",
+          "frequency": "1/Refresh"
+        },
+        "wizard": {
+          "level": 3,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency": "1/Refresh charge*3"
+        }
+      }
+    },
+    {
+      "name": "Extension",
+      "type": "Meta-Magic",
+      "school": "Neutral",
+      "range": "-",
+      "classes": {
+        "bard":{
+          "level": 3,
+          "cost": 1,
+          "max-purchases": 3,
+          "frequency" : "1/Life"
+        },
+        "druid": {
+          "level": 3,
+          "cost": 1,
+          "max-purchases": 3,
+          "frequency" : "1/Life"
+        },
+        "healer": {
+          "level": 3,
+          "cost": 1,
+          "max-purchases": 3,
+          "frequency" : "1/Life"
+        },
+        "wizard": {
+          "level": 3,
+          "cost": 1,
+          "max-purchases": 3,
+          "frequency" : "1/Life"
+        }
+      }
+    },
+    {
+      "name": "Gift of Fire",
+      "type": "Enchantment",
+      "school": "Flame",
+      "range": "Touch",
+      "materials": "Red and White Strip",
+      "classes": {
+        "druid": {
+          "level": 3,
+          "cost": 1,
+          "max-purchases": 2,
+          "frequency": "1/Refresh"
+        }
+      }
+    },
+    {
+      "name": "Entangle",
+      "type": "Magic Ball",
+      "school": "Subdual",
+      "range": "Ball",
+      "materials": "Brown Magic Ball",
+      "classes": {
+        "druid": {
+          "level": 1,
+          "cost": 1,
+          "max-purchases": 2,
+          "frequency" : "2 Balls/Unlimited"
+        },
+        "healer": {
+          "level": 2,
+          "cost": 1,
+          "max-purchases": 4,
+          "frequency" : "2 Balls/Unlimited"
+        },
+        "wizard": {
+          "level": 2,
+          "cost": 1,
+          "max-purchases": 3,
+          "frequency" : "2 Balls/Unlimited"
+        }
+      }
+    },
+    {
+      "name": "Equipment: Shield, Small",
+      "type": "Neutral",
+      "school": "Neutral",
+      "range": "-",
+      "classes": {
+        "bard": {
+          "level": 3,
+          "cost": 2,
+          "max-purchases": 1,
+          "frequency" : "-"
+        },
+        "druid": {
+          "level": 2,
+          "cost": 4,
+          "max-purchases": 1,
+          "frequency" : "-"
+        },
+        "healer": {
+          "level": 1,
+          "cost": 2,
           "max-purchases": 1,
           "frequency" : "-"
         }
@@ -335,104 +475,6 @@
       }
     },
     {
-      "name": "Heat Weapon",
-      "type": "Verbal",
-      "school": "Flame",
-      "range": "20 feet",
-      "classes": {
-        "druid": {
-          "level": 1,
-          "cost": 1,
-          "max-purchases": "-",
-          "frequency" : "1/Life charge*3"
-        },
-        "wizard":{
-          "level": 1,
-          "cost": 1,
-          "max-purchases": "-",
-          "frequency" : "1/Life"
-        }
-      }
-    },
-    {
-      "name": "Imbue Armor",
-      "type": "Enchantment",
-      "school": "Protection",
-      "range": "Touch",
-      "classes": {
-        "druid": {
-          "level": 1,
-          "cost": 1,
-          "max-purchases": "-",
-          "frequency" : "1/Refresh"
-        }
-      }
-    },
-    {
-      "name": "Mend",
-      "type": "Verbal",
-      "school": "Sorcery",
-      "range": "Touch",
-      "classes": {
-        "archer": {
-          "level": 2,
-          "cost": 0,
-          "max-purchases": 1,
-          "frequency": "1/Life"
-        },
-        "bard": {
-          "level": 2,
-          "cost": 1,
-          "max-purchases": "-",
-          "frequency" : "1/Life"
-        },
-        "druid": {
-          "level": 1,
-          "cost": 1,
-          "max-purchases": "-",
-          "frequency" : "1/Life"
-        },
-        "healer": {
-          "level": 3,
-          "cost": 1,
-          "max-purchases": "-",
-          "frequency" : "1/Life"
-        },
-        "wizard":{
-          "level": 1,
-          "cost": 1,
-          "max-purchases": "-",
-          "frequency" : "1/Life"
-        }
-      }
-    },
-    {
-      "name": "Equipment: Shield, Small",
-      "type": "Neutral",
-      "school": "Neutral",
-      "range": "-",
-      "classes": {
-        "bard": {
-          "level": 3,
-          "cost": 2,
-          "max-purchases": 1,
-          "frequency" : "-"
-        },
-        "druid": {
-          "level": 2,
-          "cost": 4,
-          "max-purchases": 1,
-          "frequency" : "-"
-        },
-        "healer": {
-          "level": 1,
-          "cost": 2,
-          "max-purchases": 1,
-          "frequency" : "-"
-        }
-      }
-    },
-    {
       "name": "Gift of Earth",
       "type": "Enchantment",
       "school": "Protection",
@@ -486,6 +528,26 @@
       }
     },
     {
+      "name": "Heat Weapon",
+      "type": "Verbal",
+      "school": "Flame",
+      "range": "20 feet",
+      "classes": {
+        "druid": {
+          "level": 1,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Life charge*3"
+        },
+        "wizard":{
+          "level": 1,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Life"
+        }
+      }
+    },
+    {
       "name": "Ice Ball",
       "type": "Magic Ball",
       "school": "Subdual",
@@ -509,6 +571,20 @@
           "cost": 1,
           "max-purchases": 3,
           "frequency" : "2 Balls/Unlimited"
+        }
+      }
+    },
+    {
+      "name": "Imbue Armor",
+      "type": "Enchantment",
+      "school": "Protection",
+      "range": "Touch",
+      "classes": {
+        "druid": {
+          "level": 1,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Refresh"
         }
       }
     },
@@ -541,6 +617,44 @@
           "cost": 1,
           "max-purchases": "-",
           "frequency" : "1/Refresh"
+        }
+      }
+    },
+    {
+      "name": "Mend",
+      "type": "Verbal",
+      "school": "Sorcery",
+      "range": "Touch",
+      "classes": {
+        "archer": {
+          "level": 2,
+          "cost": 0,
+          "max-purchases": 1,
+          "frequency": "1/Life"
+        },
+        "bard": {
+          "level": 2,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Life"
+        },
+        "druid": {
+          "level": 1,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Life"
+        },
+        "healer": {
+          "level": 3,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Life"
+        },
+        "wizard":{
+          "level": 1,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Life"
         }
       }
     },
@@ -623,114 +737,5 @@
         }
       }
     },
-    {
-      "name": "Attuned",
-      "type": "Enchantment",
-      "school": "Sorcery",
-      "range": "Touch",
-      "materials": "Yellow Strip",
-      "classes": {
-        "druid": {
-          "level": 3,
-          "cost": 1,
-          "max-purchases": 2,
-          "frequency" : "1/Refresh"
-        }
-      }
-    },
-    {
-      "name": "Bear Strength",
-      "type": "Enchantment",
-      "school": "Sorcery",
-      "range": "Touch",
-      "materials": "Red Strip",
-      "classes": {
-        "druid": {
-          "level": 3,
-          "cost": 1,
-          "max-purchases": "-",
-          "frequency" : "1/Refresh"
-        }
-      }
-    },
-    {
-      "name": "Dispel Magic",
-      "type": "Verbal",
-      "school": "Sorcery",
-      "range": "20 feet",
-      "classes": {
-        "druid": {
-          "level": 3,
-          "cost": 1,
-          "max-purchases": "-",
-          "frequency" : "1/Refresh"
-        },
-        "healer": {
-          "level": 5,
-          "cost": 1,
-          "max-purchases": "-",
-          "frequency": "1/Refresh"
-        },
-        "scout": {
-          "level": 3,
-          "cost": 0,
-          "max-purchases": "-",
-          "frequency": "1/Refresh"
-        },
-        "wizard": {
-          "level": 3,
-          "cost": 1,
-          "max-purchases": "-",
-          "frequency": "1/Refresh charge*3"
-        }
-      }
-    },
-    {
-      "name": "Extension",
-      "type": "Meta-Magic",
-      "school": "Neutral",
-      "range": "-",
-      "classes": {
-        "bard":{
-          "level": 3,
-          "cost": 1,
-          "max-purchases": 3,
-          "frequency" : "1/Life"
-        },
-        "druid": {
-          "level": 3,
-          "cost": 1,
-          "max-purchases": 3,
-          "frequency" : "1/Life"
-        },
-        "healer": {
-          "level": 3,
-          "cost": 1,
-          "max-purchases": 3,
-          "frequency" : "1/Life"
-        },
-        "wizard": {
-          "level": 3,
-          "cost": 1,
-          "max-purchases": 3,
-          "frequency" : "1/Life"
-        }
-      }
-    },
-    {
-      "name": "Gift of Fire",
-      "type": "Enchantment",
-      "school": "Flame",
-      "range": "Touch",
-      "materials": "Red and White Strip",
-      "classes": {
-        "druid": {
-          "level": 3,
-          "cost": 1,
-          "max-purchases": 2,
-          "frequency": "1/Refresh"
-        }
-      }
-    }
   ]
 }

--- a/data.json
+++ b/data.json
@@ -305,6 +305,7 @@
         }
       }
     },
+    {
       "name": "Berserk",
       "type": "Enchantment",
       "school": "Sorcery",
@@ -319,6 +320,7 @@
         }
       }
     },
+    {
       "name": "Blessed Aura",
       "type": "Enchantment",
       "school": "Protection",
@@ -333,6 +335,7 @@
         }
       }
     },
+    {
       "name": "Blessing Against Harm",
       "type": "Enchantment",
       "school": "Protection",
@@ -347,6 +350,7 @@
         }
       }
     },
+    {
       "name": "Blessing Against Wounds",
       "type": "Enchantment",
       "school": "Protection",
@@ -361,6 +365,7 @@
         }
       }
     },
+    {
       "name": "Blink",
       "type": "Verbal",
       "school": "Sorcery",
@@ -374,6 +379,7 @@
         }
       }
     },
+    {
       "name": "Blood and Thunder",
       "type": "Verbal",
       "school": "Spirit",
@@ -388,6 +394,7 @@
         }
       }
     },
+    {
       "name": "Break Concentration",
       "type": "Verbal;",
       "school": "Command",
@@ -408,6 +415,7 @@
         }
       }
     },
+    {
       "name": "Brutal Strike",
       "type": "Verbal",
       "school": "Death",

--- a/data.json
+++ b/data.json
@@ -1,11 +1,192 @@
 {
   "spells": [
     {
+      "name": "Abeyance",
+      "type": "Magic Ball",
+      "school": "Subdual",
+      "range": "Ball",
+      "materials": "Green Magic Ball",
+      "classes": {
+        "healer": {
+          "level": 5,
+          "cost": 1,
+          "max-purchases": 2,
+          "frequency" : "1 Ball/Unlimited"
+        }
+      }
+    },
+    {
+      "name": "Adaptive Blessing",
+      "type": "Enchantment",
+      "school": "Protection",
+      "range": "Touch",
+      "materials": "White strip",
+      "classes": {
+        "Healer": {
+          "level": 2,
+          "cost": 1,
+          "max-purchases": 2,
+          "frequency" : "1/Life"
+        }
+      }
+    },
+    {
+      "name": "Adaptive Protection",
+      "type": "Enchantment",
+      "school": "Protection",
+      "range": "Touch",
+      "materials": "White strip",
+      "classes": {
+        "healer": {
+          "level": 3,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Refresh"
+        }
+      }
+    },
+    {
+      "name": "Agoraphobia",
+      "type": "Verbal",
+      "school": "Command",
+      "range": "20'",
+      "classes": {
+        "bard": {
+          "level": 5,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Refresh"
+        }
+      }
+    },
+    {
+      "name": "Amplification",
+      "type": "Verbal",
+      "school": "Sorcery",
+      "range": "Touch",
+      "classes": {
+        "bard": {
+          "level": 4,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Refresh"
+        }
+      }
+    },
+    {
+      "name": "Ambulant",
+      "type": "Meta-Magic",
+      "school": "Neutral",
+      "classes": {
+        "bard": {
+          "level": 5,
+          "cost": 1,
+          "max-purchases": 2,
+          "frequency" : "1/Life"
+        },
+        "druid": {
+          "level": 5,
+          "cost": 1,
+          "max-purchases": 2,
+          "frequency" : "1/Life"
+        },
+        "healer": {
+          "level": 5,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Refresh"
+        },
+        "wizard": {
+          "level": 5,
+          "cost": 1,
+          "max-purchases": 2,
+          "frequency" : "1/Life"
+        }
+      }
+    },
+    {
+      "name": "Ancestral Armor",
+      "type": "Enchantment",
+      "school": "Protection",
+      "range": "Touch",
+      "materials": "White strip",
+      "classes": {
+        "healer": {
+          "level": 6,
+          "cost": 2,
+          "max-purchases": "-",
+          "frequency" : "1/Refresh"
+        }
+      }
+    },
+    {
+      "name": "Astral Intervention",
+      "type": "Verbal",
+      "school": "Death",
+      "range": "20'",
+      "classes": {
+        "healer": {
+          "level": 3,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Life Charge x3"
+        },
+        "wizard": {
+          "level": 2,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Life"
+        }
+      }
+    },
+    {
+      "name": "Attuned",
+      "type": "Enchantment",
+      "school": "Sorcery",
+      "range": "Touch",
+      "materials": "Yellow strip",
+      "classes": {
+        "druid": {
+          "level": 3,
+          "cost": 1,
+          "max-purchases": 2,
+          "frequency" : "1/Refresh"
+        }
+      }
+    },
+    {
+      "name": "Avatar of Nature",
+      "type": "Neutral",
+      "school": "Neutral",
+      "classes": {
+        "druid": {
+          "level": 6,
+          "cost": 1,
+          "max-purchases": 1,
+          "frequency" : "-"
+        }
+      }
+    },
+    {
+      "name": "Awe",
+      "type": "Verbal",
+      "school": "Command",
+      "range": "20'",
+      "classes": {
+        "bard": {
+          "level": 3,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Life"
+        }
+      }
+    },
+    {
       "name": "Entangle",
       "type": "Magic Ball",
       "school": "Subdual",
       "range": "Ball",
-      "materials": "Brown Ball",
+      "materials": "Brown Magic Ball",
       "classes": {
         "druid": {
           "level": 1,
@@ -309,7 +490,7 @@
       "type": "Magic Ball",
       "school": "Subdual",
       "range": "Ball",
-      "materials": "White Ball",
+      "materials": "White Magic Ball",
       "classes": {
         "druid": {
           "level": 2,

--- a/data.json
+++ b/data.json
@@ -7,7 +7,7 @@
       "range": "Ball",
       "materials": "Green Magic Ball",
       "classes": {
-        "healer": {
+        "Healer": {
           "level": 5,
           "cost": 1,
           "max-purchases": 2,
@@ -27,6 +27,12 @@
           "cost": 1,
           "max-purchases": 2,
           "frequency" : "1/Life"
+        },
+        "Scout": {
+          "level": 6,
+          "cost": 0,
+          "max-purchases": 1,
+          "frequency" : "1/Life"
         }
       }
     },
@@ -37,11 +43,25 @@
       "range": "Touch",
       "materials": "White Strip",
       "classes": {
-        "healer": {
+        "Healer": {
           "level": 3,
           "cost": 1,
           "max-purchases": "-",
           "frequency" : "1/Refresh"
+        }
+      }
+    },
+    {
+      "name": "Adrenaline",
+      "type": "Verbal",
+      "school": "Spirit",
+      "range": "Self",
+      "classes": {
+        "Barbarian": {
+          "level": 3,
+          "cost": 0,
+          "max-purchases": "-",
+          "frequency" : "Unlimited"
         }
       }
     },
@@ -51,7 +71,7 @@
       "school": "Command",
       "range": "20'",
       "classes": {
-        "bard": {
+        "Bard": {
           "level": 5,
           "cost": 1,
           "max-purchases": "-",
@@ -65,7 +85,7 @@
       "school": "Sorcery",
       "range": "Touch",
       "classes": {
-        "bard": {
+        "Bard": {
           "level": 4,
           "cost": 1,
           "max-purchases": "-",
@@ -78,25 +98,25 @@
       "type": "Meta-Magic",
       "school": "Neutral",
       "classes": {
-        "bard": {
+        "Bard": {
           "level": 5,
           "cost": 1,
           "max-purchases": 2,
           "frequency" : "1/Life"
         },
-        "druid": {
+        "Druid": {
           "level": 5,
           "cost": 1,
           "max-purchases": 2,
           "frequency" : "1/Life"
         },
-        "healer": {
+        "Healer": {
           "level": 5,
           "cost": 1,
           "max-purchases": "-",
           "frequency" : "1/Refresh"
         },
-        "wizard": {
+        "Wizard": {
           "level": 5,
           "cost": 1,
           "max-purchases": 2,
@@ -111,9 +131,23 @@
       "range": "Touch",
       "materials": "White Strip",
       "classes": {
-        "healer": {
+        "Healer": {
           "level": 6,
           "cost": 2,
+          "max-purchases": "-",
+          "frequency" : "1/Refresh"
+        }
+      }
+    },
+    {
+      "name": "Assassinate",
+      "type": "Verbal",
+      "school": "Death",
+      "range": "20'",
+      "classes": {
+        "Assassin": {
+          "level": 1,
+          "cost": 0,
           "max-purchases": "-",
           "frequency" : "1/Refresh"
         }
@@ -125,13 +159,13 @@
       "school": "Death",
       "range": "20'",
       "classes": {
-        "healer": {
+        "Healer": {
           "level": 3,
           "cost": 1,
           "max-purchases": "-",
           "frequency" : "1/Life Charge x3"
         },
-        "wizard": {
+        "Wizard": {
           "level": 2,
           "cost": 1,
           "max-purchases": "-",
@@ -146,7 +180,7 @@
       "range": "Touch",
       "materials": "Yellow Strip",
       "classes": {
-        "druid": {
+        "Druid": {
           "level": 3,
           "cost": 1,
           "max-purchases": 2,
@@ -159,7 +193,7 @@
       "type": "Neutral",
       "school": "Neutral",
       "classes": {
-        "druid": {
+        "Druid": {
           "level": 6,
           "cost": 1,
           "max-purchases": 1,
@@ -173,10 +207,22 @@
       "school": "Command",
       "range": "20'",
       "classes": {
-        "bard": {
+        "Anti-Paladin": {
+          "level": 5,
+          "cost": 0,
+          "max-purchases": 1,
+          "frequency" : "1/Life"
+        },
+        "Bard": {
           "level": 3,
           "cost": 1,
-          "max-purchases": "-",
+          "max-purchases": 1,
+          "frequency" : "1/Life"
+        },
+        "Paladin": {
+          "level": 5,
+          "cost": 0,
+          "max-purchases": 1,
           "frequency" : "1/Life"
         }
       }
@@ -187,13 +233,13 @@
       "school": "Sorcery",
       "range": "20'",
       "classes": {
-        "healer": {
+        "Healer": {
           "level": 1,
           "cost": 1,
           "max-purchases": "-",
           "frequency" : "1/Life"
         },
-        "wizard": {
+        "Wizard": {
           "level": 1,
           "cost": 1,
           "max-purchases": "-",
@@ -208,11 +254,39 @@
       "range": "Touch",
       "materials": "White Strip",
       "classes": {
-        "druid": {
+        "Druid": {
           "level": 1,
           "cost": 1,
           "max-purchases": 2,
           "frequency" : "1/Refresh"
+        }
+      }
+    },
+    {
+      "name": "Battlefield Triage",
+      "type": "Enchantment",
+      "school": "Spirit",
+      "range": "Self or Touch",
+      "materials": "Four Yellow Strips",
+      "classes": {
+        "Bard": {
+          "level": 3,
+          "cost": 1,
+          "max-purchases": 1,
+          "frequency" : "1/Refresh"
+        }
+      }
+    },
+    {
+      "name": "Battlemage",
+      "type": "Neutral",
+      "school": "Neutral",
+      "classes": {
+        "Wizard": {
+          "level": 6,
+          "cost": 2,
+          "max-purchases": 1,
+          "frequency" : "-"
         }
       }
     },
@@ -223,11 +297,134 @@
       "range": "Touch",
       "materials": "Red Strip",
       "classes": {
-        "druid": {
+        "Druid": {
           "level": 3,
           "cost": 1,
           "max-purchases": "-",
           "frequency" : "1/Refresh"
+        }
+      }
+    },
+      "name": "Berserk",
+      "type": "Enchantment",
+      "school": "Sorcery",
+      "range": "Self",
+      "materials": "Red Strip",
+      "classes": {
+        "Barbarian": {
+          "level": 1,
+          "cost": 0,
+          "max-purchases": 1,
+          "frequency" : "-"
+        }
+      }
+    },
+      "name": "Blessed Aura",
+      "type": "Enchantment",
+      "school": "Protection",
+      "range": "Touch",
+      "materials": "White Strip",
+      "classes": {
+        "Healer": {
+          "level": 5,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Refresh"
+        }
+      }
+    },
+      "name": "Blessing Against Harm",
+      "type": "Enchantment",
+      "school": "Protection",
+      "range": "Touch",
+      "materials": "White Strip",
+      "classes": {
+        "Healer": {
+          "level": 4,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Refresh"
+        }
+      }
+    },
+      "name": "Blessing Against Wounds",
+      "type": "Enchantment",
+      "school": "Protection",
+      "range": "Touch",
+      "materials": "White Strip",
+      "classes": {
+        "Healer": {
+          "level": 1,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Life"
+        }
+      }
+    },
+      "name": "Blink",
+      "type": "Verbal",
+      "school": "Sorcery",
+      "range": "Self",
+      "classes": {
+        "Assassin": {
+          "level": 3,
+          "cost": 0,
+          "max-purchases": 1,
+          "frequency" : "2/Life"
+        }
+      }
+    },
+      "name": "Blood and Thunder",
+      "type": "Verbal",
+      "school": "Spirit",
+      "range": "Self",
+      "materials": "White Strip",
+      "classes": {
+        "Barbarian": {
+          "level": 1,
+          "cost": 0,
+          "max-purchases": 1,
+          "frequency" : "2/Refresh"
+        }
+      }
+    },
+      "name": "Break Concentration",
+      "type": "Verbal;",
+      "school": "Command",
+      "range": "Unlimited",
+      "classes": {
+        "Bard": {
+          "level": 3,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : ""
+        }
+      "classes": {
+        "Wizard": {
+          "level": 2,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Life"
+        }
+      }
+    },
+      "name": "Brutal Strike",
+      "type": "Verbal",
+      "school": "Death",
+      "range": "Unlimited",
+      "classes": {
+        "Anti-Paladin": {
+          "level": 4,
+          "cost": 0,
+          "max-purchases": 1,
+          "frequency" : "1/Life"
+        }
+      "classes": {
+        "Barbarin": {
+          "level": 5,
+          "cost": 0,
+          "max-purchases": 1,
+          "frequency" : "1/Life"
         }
       }
     },
@@ -237,25 +434,25 @@
       "school": "Neutral",
       "range": "Touch",
       "classes": {
-        "bard":{
+        "Bard":{
           "level": 1,
           "cost": 0,
           "max-purchases": 1,
           "frequency" : "Unlimited"
         },
-        "druid": {
+        "Druid": {
           "level": 1,
           "cost": 0,
           "max-purchases": 1,
           "frequency" : "Unlimited"
         },
-        "healer": {
+        "Healer": {
           "level": 1,
           "cost": 0,
           "max-purchases": 1,
           "frequency" : "Unlimited"
         },
-        "wizard":{
+        "Wizard":{
           "level": 1,
           "cost": 0,
           "max-purchases": 1,
@@ -270,7 +467,7 @@
       "range": "Self/Touch",
       "materials": "5 Red Strips",
       "classes": {
-        "druid": {
+        "Druid": {
           "level": 1,
           "cost": 1,
           "max-purchases": 1,
@@ -284,29 +481,29 @@
       "school": "Sorcery",
       "range": "20 feet",
       "classes": {
-        "druid": {
+        "Druid": {
           "level": 3,
           "cost": 1,
           "max-purchases": "-",
           "frequency" : "1/Refresh"
         },
-        "healer": {
+        "Healer": {
           "level": 5,
           "cost": 1,
           "max-purchases": "-",
           "frequency": "1/Refresh"
         },
-        "scout": {
+        "Scout": {
           "level": 3,
           "cost": 0,
-          "max-purchases": "-",
+          "max-purchases": 1,
           "frequency": "1/Refresh"
         },
-        "wizard": {
+        "Wizard": {
           "level": 3,
           "cost": 1,
           "max-purchases": "-",
-          "frequency": "1/Refresh charge*3"
+          "frequency": "1/Refresh Charge x3"
         }
       }
     },
@@ -316,25 +513,25 @@
       "school": "Neutral",
       "range": "-",
       "classes": {
-        "bard":{
+        "Bard":{
           "level": 3,
           "cost": 1,
           "max-purchases": 3,
           "frequency" : "1/Life"
         },
-        "druid": {
+        "Druid": {
           "level": 3,
           "cost": 1,
           "max-purchases": 3,
           "frequency" : "1/Life"
         },
-        "healer": {
+        "Healer": {
           "level": 3,
           "cost": 1,
           "max-purchases": 3,
           "frequency" : "1/Life"
         },
-        "wizard": {
+        "Wizard": {
           "level": 3,
           "cost": 1,
           "max-purchases": 3,
@@ -349,7 +546,7 @@
       "range": "Touch",
       "materials": "Red and White Strip",
       "classes": {
-        "druid": {
+        "Druid": {
           "level": 3,
           "cost": 1,
           "max-purchases": 2,
@@ -364,19 +561,19 @@
       "range": "Ball",
       "materials": "Brown Magic Ball",
       "classes": {
-        "druid": {
+        "Druid": {
           "level": 1,
           "cost": 1,
           "max-purchases": 2,
           "frequency" : "2 Balls/Unlimited"
         },
-        "healer": {
+        "Healer": {
           "level": 2,
           "cost": 1,
           "max-purchases": 4,
           "frequency" : "2 Balls/Unlimited"
         },
-        "wizard": {
+        "Wizard": {
           "level": 2,
           "cost": 1,
           "max-purchases": 3,
@@ -390,19 +587,19 @@
       "school": "Neutral",
       "range": "-",
       "classes": {
-        "bard": {
+        "Bard": {
           "level": 3,
           "cost": 2,
           "max-purchases": 1,
           "frequency" : "-"
         },
-        "druid": {
+        "Druid": {
           "level": 2,
           "cost": 4,
           "max-purchases": 1,
           "frequency" : "-"
         },
-        "healer": {
+        "Healer": {
           "level": 1,
           "cost": 2,
           "max-purchases": 1,
@@ -416,25 +613,25 @@
       "school": "Neutral",
       "range": "-",
       "classes": {
-        "bard":{
+        "Bard":{
           "level": 1,
           "cost": 2,
           "max-purchases": 2,
           "frequency" : "-"
         },
-        "druid": {
+        "Druid": {
           "level": 1,
           "cost": 2,
           "max-purchases": 2,
           "frequency" : "-"
         },
-        "healer": {
+        "Healer": {
           "level": 1,
           "cost": 3,
           "max-purchases": 1,
           "frequency" : "-"
         },
-        "wizard":{
+        "Wizard":{
           "level": 1,
           "cost": 2,
           "max-purchases": 1,
@@ -448,25 +645,25 @@
       "school": "Neutral",
       "range": "-",
       "classes": {
-        "bard":{
+        "Bard":{
           "level": 1,
           "cost": 2,
           "max-purchases": 2,
           "frequency" : "-"
         },
-        "druid": {
+        "Druid": {
           "level": 1,
           "cost": 2,
           "max-purchases": 2,
           "frequency" : "-"
         },
-        "healer": {
+        "Healer": {
           "level": 1,
           "cost": 2,
           "max-purchases": 2,
           "frequency" : "-"
         },
-        "wizard":{
+        "Wizard":{
           "level": 1,
           "cost": 2,
           "max-purchases": 2,
@@ -481,7 +678,7 @@
       "range": "Touch",
       "materials": "White Strip",
       "classes": {
-        "druid": {
+        "Druid": {
           "level": 2,
           "cost": 1,
           "max-purchases": 2,
@@ -495,19 +692,19 @@
       "school": "Spirit",
       "range": "Touch",
       "classes": {
-        "monk":{
+        "Monk":{
           "level": 4,
           "cost": 0,
           "max-purchases": "-",
           "frequency" : "Self-Only 1/Life"
         },
-        "druid": {
+        "Druid": {
           "level": 2,
           "cost": 1,
           "max-purchases": "-",
           "frequency" : "1/Life"
         },
-        "healer": {
+        "Healer": {
           "level": 1,
           "cost": 1,
           "max-purchases": 1,
@@ -517,9 +714,9 @@
           "level": 1,
           "cost": 0,
           "max-purchases": 1,
-          "frequency" : "1/Refresh charge *3"
+          "frequency" : "1/Refresh Charge x3"
         },
-        "scout":{
+        "Scout":{
           "level": 2,
           "cost": 0,
           "max-purchases": 1,
@@ -533,13 +730,13 @@
       "school": "Flame",
       "range": "20 feet",
       "classes": {
-        "druid": {
+        "Druid": {
           "level": 1,
           "cost": 1,
           "max-purchases": "-",
-          "frequency" : "1/Life charge*3"
+          "frequency" : "1/Life Charge x3"
         },
-        "wizard":{
+        "Wizard":{
           "level": 1,
           "cost": 1,
           "max-purchases": "-",
@@ -554,19 +751,19 @@
       "range": "Ball",
       "materials": "White Magic Ball",
       "classes": {
-        "druid": {
+        "Druid": {
           "level": 2,
           "cost": 1,
           "max-purchases": 2,
           "frequency" : "2 Balls/Unlimited"
         },
-        "healer": {
+        "Healer": {
           "level": 3,
           "cost": 1,
           "max-purchases": 2,
           "frequency" : "2 Balls/Unlimited"
         },
-        "wizard": {
+        "Wizard": {
           "level": 3,
           "cost": 1,
           "max-purchases": 3,
@@ -580,7 +777,7 @@
       "school": "Protection",
       "range": "Touch",
       "classes": {
-        "druid": {
+        "Druid": {
           "level": 1,
           "cost": 1,
           "max-purchases": "-",
@@ -594,25 +791,25 @@
       "school": "Neutral",
       "range": "-",
       "classes": {
-        "bard":{
+        "Bard":{
           "level": 2,
           "cost": 1,
           "max-purchases": 4,
           "frequency" : "1/Refresh"
         },
-        "druid": {
+        "Druid": {
           "level": 2,
           "cost": 1,
           "max-purchases": 4,
           "frequency" : "1/Refresh"
         },
-        "healer": {
+        "Healer": {
           "level": 2,
           "cost": 2,
           "max-purchases": 2,
           "frequency" : "1/Life"
         },
-        "wizard": {
+        "Wizard": {
           "level": 2,
           "cost": 1,
           "max-purchases": "-",
@@ -626,31 +823,31 @@
       "school": "Sorcery",
       "range": "Touch",
       "classes": {
-        "archer": {
+        "Archer": {
           "level": 2,
           "cost": 0,
           "max-purchases": 1,
           "frequency": "1/Life"
         },
-        "bard": {
+        "Bard": {
           "level": 2,
           "cost": 1,
           "max-purchases": "-",
           "frequency" : "1/Life"
         },
-        "druid": {
+        "Druid": {
           "level": 1,
           "cost": 1,
           "max-purchases": "-",
           "frequency" : "1/Life"
         },
-        "healer": {
+        "Healer": {
           "level": 3,
           "cost": 1,
           "max-purchases": "-",
           "frequency" : "1/Life"
         },
-        "wizard":{
+        "Wizard":{
           "level": 1,
           "cost": 1,
           "max-purchases": "-",
@@ -665,23 +862,23 @@
       "range": "Touch",
       "materials": "Red Strip",
       "classes": {
-        "druid": {
+        "Druid": {
           "level": 2,
           "cost": 1,
           "max-purchases": 4,
           "frequency" : "1/Refresh"
         },
-        "assassin": {
+        "Assassin": {
           "level": 2,
           "cost": 0,
           "max-purchases": 1,
-          "frequency" : "1/Life charge*3"
+          "frequency" : "Unlimited"
         },
-        "anti-paladin": {
+        "Anti-Paladin": {
           "level": 2,
           "cost": 0,
           "max-purchases": 1,
-          "frequency" : "1/Refresh charge*3"
+          "frequency" : "1/Refresh Charge x3"
         }
       }
     },
@@ -691,31 +888,31 @@
       "school": "Sorcery",
       "range": "Touch",
       "classes": {
-        "bard": {
+        "Bard": {
           "level": 1,
           "cost": 1,
           "max-purchases": "-",
           "frequency": "1/Life"
         },
-        "druid": {
+        "Druid": {
           "level": 2,
           "cost": 1,
           "max-purchases": "-",
           "frequency" : "1/Life"
         },
-        "healer": {
+        "Healer": {
           "level": 1,
           "cost": 1,
           "max-purchases": "-",
-          "frequency" : "2/Life charge*3"
+          "frequency" : "2/Life Charge x3"
         },
-        "scout": {
+        "Scout": {
           "level": 2,
           "cost": 0,
           "max-purchases": 1,
-          "frequency" : "1/Life charge*3"
+          "frequency" : "1/Life Charge x3"
         },
-        "wizard": {
+        "Wizard": {
           "level": 2,
           "cost": 1,
           "max-purchases": "-",
@@ -729,11 +926,11 @@
       "school": "Protection",
       "range": "Self",
       "classes": {
-        "druid": {
+        "Druid": {
           "level": 2,
           "cost": 1,
           "max-purchases": "-",
-          "frequency" : "1/Refresh charge*3"
+          "frequency" : "1/Refresh Charge x3"
         }
       }
     },

--- a/data.json
+++ b/data.json
@@ -425,8 +425,7 @@
           "cost": 0,
           "max-purchases": 1,
           "frequency" : "1/Life"
-        }
-      "classes": {
+        },
         "Barbarin": {
           "level": 5,
           "cost": 0,

--- a/data.json
+++ b/data.json
@@ -435,6 +435,20 @@
       }
     },
     {
+      "name": "Call Lightning",
+      "type": "Verbal",
+      "school": "Flame",
+      "range": "20'",
+      "classes": {
+        "Druid": {
+          "level": 6,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Refresh"
+        }
+      }
+    },
+    {
       "name": "Cancel",
       "type": "Neutral",
       "school": "Neutral",
@@ -467,6 +481,63 @@
       }
     },
     {
+      "name": "Circle of Protection",
+      "type": "Enchantment",
+      "school": "Protection",
+      "range": "Self",
+      "materials": "White Strip",
+      "classes": {
+        "Healer": {
+          "level": 4,
+          "cost": 1,
+          "max-purchases": 1,
+          "frequency" : "1/Refresh Charge x10"
+        }
+      }
+    },
+    {
+      "name": "Combat Caster",
+      "type": "Neutral",
+      "school": "Neutral",
+      "classes": {
+        "Bard": {
+          "level": 6,
+          "cost": 2,
+          "max-purchases": 1,
+          "frequency" : "-"
+        }
+      }
+    },
+    {
+      "name": "Confidence",
+      "type": "Verbal",
+      "school": "Sorcery",
+      "range": "Touch",
+      "classes": {
+        "Bard": {
+          "level": 1,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Refresh Charge x5"
+        }
+      }
+    },
+    {
+      "name": "Contagion",
+      "type": "Enchantment",
+      "school": "Death",
+      "range": "Touch",
+      "materials": "Red Strip",
+      "classes": {
+        "Wizard": {
+          "level": 5,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Refresh"
+        }
+      }
+    },
+    {
       "name": "Corrosive Mist",
       "type": "Enchantment",
       "school": "Death",
@@ -477,7 +548,91 @@
           "level": 1,
           "cost": 1,
           "max-purchases": 1,
+          "frequency" : "1/Refresh"
+        }
+      }
+    },
+    {
+      "name": "Coup de Grace",
+      "type": "Verbal",
+      "school": "Death",
+      "range": "20'",
+      "classes": {
+        "Assassin": {
+          "level": 6,
+          "cost": 0,
+          "max-purchases": ,
+          "frequency" : "1/Life"
+        }
+      }
+    },
+    {
+      "name": "Dervish",
+      "type": "Neutral",
+      "school": "Neutral",
+      "classes": {
+        "Bard": {
+          "level": 6,
+          "cost": 2,
+          "max-purchases": 1,
           "frequency" : "-"
+        }
+      }
+    },
+    {
+      "name": "Destroy Armor",
+      "type": "Verbal",
+      "school": "Death",
+      "range": "20'",
+      "classes": {
+        "Wizard": {
+          "level": 4,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "2/Refresh"
+        }
+      }
+    },
+    {
+      "name": "Destruction Arrow",
+      "type": "Specialty Arrow",
+      "school": "Sorcery",
+      "materials": "Red Arrow",
+      "classes": {
+        "Archer": {
+          "level": 1,
+          "cost": 0,
+          "max-purchases": 1,
+          "frequency" : "1 Arrow/Unlimited"
+        }
+      }
+    },
+    {
+      "name": "Dimensional Rift",
+      "type": "Verbal",
+      "school": "Sorcery",
+      "range": "20'",
+      "classes": {
+        "Wizard": {
+          "level": 4,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Refresh"
+        }
+      }
+    },
+    {
+      "name": "Discordia",
+      "type": "Enchantment",
+      "school": "Command",
+      "range": "Self",
+      "materials": "Red Strip",
+      "classes": {
+        "Bard": {
+          "level": 5,
+          "cost": 1,
+          "max-purchases": 1,
+          "frequency" : "1/Refresh"
         }
       }
     },
@@ -510,6 +665,20 @@
           "cost": 1,
           "max-purchases": "-",
           "frequency": "1/Refresh Charge x3"
+        }
+      }
+    },
+    {
+      "name": "Dragged Below",
+      "type": "Verbal",
+      "school": "Death",
+      "range": "20'",
+      "classes": {
+        "Wizard": {
+          "level": 3,
+          "cost": 1,
+          "max-purchases": "-",
+          "frequency" : "1/Refresh"
         }
       }
     },


### PR DESCRIPTION
Not sure how these were ordered previously, but I sorted them alphabetically by name.

I think that, rather than have "-" as the Max Purchases, we should remove that property, like we do with non-material spells and abilities. Also, Blood & Thunder doesn't have a material component, but the white strip is required, so I put it in. All class names are capitalized, and Charge counts have Xs instead of asterisks, as well.
